### PR TITLE
xtimer: remove return value for usleep_until

### DIFF
--- a/sys/include/xtimer.h
+++ b/sys/include/xtimer.h
@@ -161,9 +161,8 @@ static inline void xtimer_spin(uint32_t microseconds);
  *
  * @param[in] last_wakeup base time for the wakeup
  * @param[in] usecs time in microseconds that will be added to last_wakeup
- * @return 0 on success, < 0 on error
  */
-int xtimer_usleep_until(uint32_t *last_wakeup, uint32_t usecs);
+void xtimer_usleep_until(uint32_t *last_wakeup, uint32_t usecs);
 
 /**
  * @brief Set a timer that sends a message

--- a/sys/xtimer/xtimer.c
+++ b/sys/xtimer/xtimer.c
@@ -44,8 +44,7 @@ void _xtimer_sleep(uint32_t offset, uint32_t long_offset)
     mutex_lock(&mutex);
 }
 
-int xtimer_usleep_until(uint32_t *last_wakeup, uint32_t interval) {
-    int ret = 0;
+void xtimer_usleep_until(uint32_t *last_wakeup, uint32_t interval) {
     xtimer_t timer;
     mutex_t mutex = MUTEX_INIT;
 
@@ -81,8 +80,6 @@ int xtimer_usleep_until(uint32_t *last_wakeup, uint32_t interval) {
 
 out:
     *last_wakeup = xtimer_now();
-
-    return ret;
 }
 
 static void _callback_msg(void* arg)


### PR DESCRIPTION
Just throw it away if you dislike the 8 bytes more of ROM.
