### PR TITLE
evtimer: add peek functionality to look into future

### DIFF
--- a/sys/evtimer/evtimer.c
+++ b/sys/evtimer/evtimer.c
@@ -142,7 +142,7 @@ void evtimer_del(evtimer_t *evtimer, evtimer_event_t *event)
 }
 
 bool evtimer_peek(evtimer_t *evtimer, evtimer_peek_cb_t *peek_cb,
-                  uint64_t limit)
+                  void *peek_ctx, uint64_t limit)
 {
     bool res = false;
     unsigned state = irq_disable();
@@ -152,7 +152,7 @@ bool evtimer_peek(evtimer_t *evtimer, evtimer_peek_cb_t *peek_cb,
     DEBUG("evtimer_peek(): searching events in the next %"PRIu32" ms\n",
           limit);
     while((event != NULL) && (acc <= limit)) {
-        if (peek_cb(event)) {
+        if (peek_cb(event, peek_ctx)) {
             res = true;
             break;
         }

--- a/sys/include/evtimer.h
+++ b/sys/include/evtimer.h
@@ -54,7 +54,7 @@ extern "C" {
 
 /** forward declaration */
 typedef struct evtimer_event evtimer_event_t;
-typedef bool (*evtimer_peek_cb_t)(evtimer_event_t *event);
+typedef bool (*evtimer_peek_cb_t)(evtimer_event_t *event, void *ctx);
 
 typedef struct {
     xtimer_t timer;
@@ -85,7 +85,7 @@ static inline void evtimer_add_msg(evtimer_t *evtimer,
 
 void evtimer_del(evtimer_t *evtimer, evtimer_event_t *event);
 bool evtimer_peek(evtimer_t *evtimer, evtimer_peek_cb_t *peek_cb,
-                  uint64_t limit);
+                  void *peek_ctx, uint64_t limit);
 void evtimer_msg_handler(void *arg);
 
 static inline void evtimer_init_msg(evtimer_t *evtimer)

--- a/sys/include/evtimer.h
+++ b/sys/include/evtimer.h
@@ -79,7 +79,7 @@ static inline void evtimer_add_msg(evtimer_t *evtimer,
                                    kernel_pid_t target_pid)
 {
     /* use sender_pid field to get target_pid into callback function */
-    event->msg.sender_pid;
+    event->msg.sender_pid = target_pid;
     evtimer_add(evtimer, &event->event);
 }
 

--- a/sys/include/evtimer.h
+++ b/sys/include/evtimer.h
@@ -16,7 +16,7 @@
  *
  * Compared to xtimer, evtimer offers:
  *
- * - only relative 32bit milisecond timer values
+ * - only relative 32bit millisecond timer values
  *   Events can be scheduled with a relative offset of up to ~49.7 days in the
  *   future.
  *   For time-critical stuff, use xtimer!
@@ -39,8 +39,10 @@
 #ifndef EVTIMER_H
 #define EVTIMER_H
 
+#include <stdbool.h>
 #include <stdint.h>
 
+#include "kernel_types.h"
 #include "msg.h"
 #include "xtimer.h"
 
@@ -48,8 +50,11 @@
 extern "C" {
 #endif
 
+#define EVTIMER_PEEK_LIMIT_INFINITY (UINT64_MAX)
+
 /** forward declaration */
 typedef struct evtimer_event evtimer_event_t;
+typedef bool (*evtimer_peek_cb_t)(evtimer_event_t *event);
 
 typedef struct {
     xtimer_t timer;
@@ -68,8 +73,26 @@ typedef struct {
 
 void evtimer_init(evtimer_t *evtimer, void(*handler)(void*));
 void evtimer_add(evtimer_t *evtimer, evtimer_event_t *event);
+
+static inline void evtimer_add_msg(evtimer_t *evtimer,
+                                   evtimer_msg_event_t *event,
+                                   kernel_pid_t target_pid)
+{
+    /* use sender_pid field to get target_pid into callback function */
+    event->msg.sender_pid;
+    evtimer_add(evtimer, &event->event);
+}
+
 void evtimer_del(evtimer_t *evtimer, evtimer_event_t *event);
+bool evtimer_peek(evtimer_t *evtimer, evtimer_peek_cb_t *peek_cb,
+                  uint64_t limit);
 void evtimer_msg_handler(void *arg);
+
+static inline void evtimer_init_msg(evtimer_t *evtimer)
+{
+    evtimer_init(evtimer, evtimer_msg_handler);
+}
+
 void evtimer_print(evtimer_t *evtimer);
 
 #ifdef __cplusplus


### PR DESCRIPTION
Will return true, if `peek_cb` returns true for any event currently
scheduled.

I also added some wrappers for `evtimer_msg_event_t` to have it similar easy to understand like `xtimer_send_msg()`.
