### PR TITLE
sys: random: make fallback seed configurable at compile time

### DIFF
--- a/sys/include/random.h
+++ b/sys/include/random.h
@@ -32,6 +32,14 @@
 extern "C" {
 #endif
 
+#ifndef RANDOM_DEFAULT_SEED
+/**
+ * @brief   Seed selected when all tries to collect seeds from a random source
+ *          failed
+ */
+#define RANDOM_DEFAULT_SEED (1)
+#endif
+
 /**
  * @brief Enables support for floating point random number generation
  */

--- a/sys/random/seed.c
+++ b/sys/random/seed.c
@@ -34,7 +34,7 @@ void auto_init_random(void)
     luid_get(&seed, 4);
 #else
     LOG_WARNING("random: NO SEED AVAILABLE!\n");
-    seed = 1;
+    seed = RANDOM_SEED_DEFAULT;
 #endif
     DEBUG("random: using seed value %u\n", (unsigned)seed);
     random_init(seed);


### PR DESCRIPTION
Defines the fallback as a macro that can be changed at compile time.