### PR TITLE
at: add out of band data

### DIFF
--- a/drivers/include/at.h
+++ b/drivers/include/at.h
@@ -37,6 +37,7 @@
 
 #include "isrpipe.h"
 #include "periph/uart.h"
+#include "clist.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -50,12 +51,36 @@ extern "C" {
 /** Shortcut for getting end of line length */
 #define AT_EOL_LEN  (sizeof(AT_EOL) - 1)
 
+#ifndef AT_BUF_SIZE
+/** Internal buffer size used to process out-of-band data */
+#define AT_BUF_SIZE (128)
+#endif
+
+/**
+ * @brief   Out-of-band data callback
+ *
+ * @param[in]   arg     optional argument
+ * @param[in]   urc     urc string received from the device
+ */
+typedef void (*at_oob_cb_t)(void *arg, const char *urc);
+
+/**
+ * @brief   Out-of-band data structure
+ */
+typedef struct {
+    clist_node_t list_node; /**< node list */
+    at_oob_cb_t cb;         /**< callback */
+    const char *urc;        /**< URC which must match */
+    void *arg;              /**< optional argument */
+} at_oob_t;
+
 /**
  * @brief AT device structure
  */
 typedef struct {
     isrpipe_t isrpipe;      /**< isrpipe used for getting data from uart */
     uart_t uart;            /**< UART device where the AT device is attached */
+    clist_node_t oob_list;
 } at_dev_t;
 
 /**
@@ -195,6 +220,31 @@ ssize_t at_readline(at_dev_t *dev, char *resp_buf, size_t len, uint32_t timeout)
  * @param[in]   dev     device to operate on
  */
 void at_drain(at_dev_t *dev);
+
+/**
+ * @brief   add a callback for an out-of-bound data
+ *
+ * @param[in]   dev     device to operate on
+ * @param[in]   oob     out-of-band value to register
+ */
+void at_add_oob(at_dev_t *dev, at_oob_t *oob);
+
+/**
+ * @brief   remove an out-of-band data from the list
+ *
+ * @param[in]   dev     device to operate on
+ * @param[in]   oob     out-of-band value to remove
+ */
+void at_remove_oob(at_dev_t *dev, at_oob_t *oob);
+
+/**
+ * @brief   process out-of-band data received from the device
+ *
+ * The function returns immediately if no data is available to be read.
+ *
+ * @param[in]   dev     device to operate on
+ */
+void at_process_oob(at_dev_t *dev);
 
 #ifdef __cplusplus
 }

--- a/sys/include/isrpipe.h
+++ b/sys/include/isrpipe.h
@@ -65,10 +65,21 @@ void isrpipe_init(isrpipe_t *isrpipe, char *buf, size_t bufsize);
 int isrpipe_write_one(isrpipe_t *isrpipe, char c);
 
 /**
+ * @brief   Try to read data from isrpipe (non blocking)
+ *
+ * @param[in]   isrpipe     isrpipe object to operate on
+ * @param[out]  buffer      buffer to write to
+ * @param[in]   count       number of bytes to read
+ *
+ * @returns     number of byte read
+ */
+int isrpipe_try_read(isrpipe_t *isrpipe, char *buf, size_t count);
+
+/**
  * @brief   Read data from isrpipe (blocking)
  *
  * @param[in]   isrpipe    isrpipe object to operate on
- * @param[in]   buf        buffer to write to
+ * @param[out]  buf        buffer to write to
  * @param[in]   count      number of bytes to read
  *
  * @returns     number of bytes read
@@ -84,7 +95,7 @@ int isrpipe_read(isrpipe_t *isrpipe, char *buf, size_t count);
  * @note This function might return less than @p count bytes
  *
  * @param[in]   isrpipe    isrpipe object to operate on
- * @param[in]   buf        buffer to write to
+ * @param[out]  buf        buffer to write to
  * @param[in]   count      number of bytes to read
  * @param[in]   timeout    timeout in ms
  *
@@ -100,7 +111,7 @@ int isrpipe_read_timeout(isrpipe_t *isrpipe, char *buf, size_t count, uint32_t t
  * timeout or when @p count bytes have been received.
  *
  * @param[in]   isrpipe    isrpipe object to operate on
- * @param[in]   buf        buffer to write to
+ * @param[out]  buf        buffer to write to
  * @param[in]   count      number of bytes to read
  * @param[in]   timeout    timeout in ms
  *

--- a/sys/isrpipe/isrpipe.c
+++ b/sys/isrpipe/isrpipe.c
@@ -50,6 +50,11 @@ int isrpipe_read(isrpipe_t *isrpipe, char *buffer, size_t count)
     return res;
 }
 
+int isrpipe_try_read(isrpipe_t *isrpipe, char *buf, size_t count)
+{
+    return tsrb_get(&isrpipe->tsrb, buf, count);
+}
+
 typedef struct {
     mutex_t *mutex;
     int flag;


### PR DESCRIPTION
Hi Kaspar,

I wanted your feedback on this idea (inspired from mbed ATCmdParser to be honest ;).

It should solve the asynchronous issue (for instance SMS reception) we discussed in the summit.

The implementation is really simple and allow any upper layer to call the `at_process_oob` when idle.
Then I imagine a 'modem' thread to manage incoming commands and call this function when idle.

Please let me know what you think, I'd like to move forward on the modem topic!

Cheers,