### PR TITLE
firmware: remove metadata_type from struct

### DIFF
--- a/dist/tools/firmware/sign.c
+++ b/dist/tools/firmware/sign.c
@@ -86,6 +86,8 @@ int sign(int argc, char *argv[])
     /* calculate metadata checksum */
     metadata.metadata.chksum = firmware_metadata_checksum(&metadata.metadata);
 
+    metadata.metadata_type = FIRMWARE_METADATA_RIOTBOOT;
+
     /* sign */
     firmware_simple_sign(&metadata, sk);
 

--- a/sys/firmware/firmware_simple.c
+++ b/sys/firmware/firmware_simple.c
@@ -44,7 +44,7 @@ void firmware_simple_print(firmware_simple_t *simple)
     printf("Firmware Version: %#x\n", (unsigned)simple->metadata.version);
     printf("Firmware start address: 0x%08x\n", (unsigned)simple->metadata.start_addr);
     /* Only output full info if the metadata_type matches */
-    if (simple->metadata.metadata_type == FIRMWARE_METADATA_RIOTBOOT)
+    if (simple->metadata_type == FIRMWARE_METADATA_RIOTBOOT)
     {
         printf("Firmware APPID: %#x\n", (unsigned)simple->appid);
         printf("Firmware Size: %" PRIu32 "\n", simple->size);

--- a/sys/include/firmware.h
+++ b/sys/include/firmware.h
@@ -123,7 +123,7 @@ extern "C" {
  *
  *  Includes magic number, version, and start address.
  */
-#define FIRMWARE_CHECKSUM_LEN       (16)
+#define FIRMWARE_CHECKSUM_LEN       (12)
 
 /**
  *  @brief Length of metadata prefixed to firmware binaries
@@ -145,8 +145,6 @@ typedef struct {
     uint32_t magic_number;              /**< metadata magic_number (always "RIOT")  */
     uint32_t version;                   /**< Integer representing firmware version  */
     uint32_t start_addr;                /**< Start address in flash                 */
-    uint32_t metadata_type;             /**< Type of metadata, 16 bits type,
-                                          16 bit version */
     uint32_t chksum;                    /**< checksum of metadata                   */
 } firmware_metadata_t;
 /** @} */

--- a/sys/include/firmware/simple.h
+++ b/sys/include/firmware/simple.h
@@ -42,6 +42,8 @@
 
 typedef struct {
     firmware_metadata_t metadata;       /**< generic bootloader specific firmware info */
+    uint32_t metadata_type;             /**< Type of metadata, 16 bits type,
+                                          16 bit version */
     uint32_t appid;                     /**< Application type ID */
     uint32_t size;                      /**< Size of firmware image */
     uint8_t hash[SHA256_DIGEST_LENGTH]; /**< SHA256 Hash of firmware image */


### PR DESCRIPTION
Removes the metadata_type from the `firmware_metadata_t` struct as discussed. I haven't tested it on an actual board yet.