### PR TITLE
V4 support for non 0x000000 FLASH BASE boards

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,6 @@ scan-build/
 
 # compile_and_test_for_boards default "results" directory
 results/
+
+# suit manidest secret key
+secret.key

--- a/makefiles/boot/riotboot.mk
+++ b/makefiles/boot/riotboot.mk
@@ -141,8 +141,11 @@ riotboot/slot1: $(SLOT1_RIOT_BIN)
 riotboot/flash: riotboot/flash-slot0 riotboot/flash-bootloader
 
 # include suit targets
-#include $(RIOTMAKE)/suit.inc.mk
+ifneq (,$(filter suit_v1, $(USEMODULE)))
+include $(RIOTMAKE)/suit.inc.mk
+else
 include $(RIOTMAKE)/suit.v4.inc.mk
+endif
 
 else
 riotboot:

--- a/sys/suit/v4/handlers.c
+++ b/sys/suit/v4/handlers.c
@@ -111,7 +111,8 @@ static int _cond_comp_offset(suit_v4_manifest_t *manifest, int key, CborValue *i
     (void)key;
     uint32_t offset;
     suit_cbor_get_uint32(it, &offset);
-    uint32_t other_offset = (uint32_t)riotboot_slot_get_hdr(riotboot_slot_other());
+    uint32_t other_offset = (uint32_t)riotboot_slot_get_hdr(riotboot_slot_other()) \
+                            - CPU_FLASH_BASE;
     LOG_INFO("Comparing manifest offset %u with other slot offset %u\n",
            (unsigned)offset, (unsigned)other_offset);
     return other_offset == offset ? 0 : -1;


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

1. Old modifications to README
2. Add secret.key yo git ignore
3. Add suit version makefile according to version
4.  Check manifest offset taking CPU_FLASH_BASE into account

With 4 this PR adds support for nucleo-l152re, iotlab-m3.

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
