### PR TITLE
pkg/nanopb: simplify setup procedure

### DIFF
--- a/pkg/nanopb/nanopb.inc.mk
+++ b/pkg/nanopb/nanopb.inc.mk
@@ -1,5 +1,5 @@
 PROTOC ?= protoc
-PROTOC_GEN_NANOPB ?= protoc-gen-nanopb
+PROTOC_GEN_NANOPB ?= $(PKGDIRBASE)/nanopb/generator/protoc-gen-nanopb
 
 PROTOBUF_FILES ?= $(wildcard *.proto)
 GENSRC   += $(PROTOBUF_FILES:%.proto=$(BINDIR)/$(MODULE)/%.pb.c)
@@ -15,6 +15,7 @@ $(GENSRC): $(PROTOBUF_FILES)
 	$(Q)D=$(BINDIR)/$(MODULE) && \
 	  mkdir -p "$$D" && \
 		cd $(CURDIR) && \
+		make -C $(PKGDIRBASE)/nanopb/generator/proto && \
 		for protofile in $(PROTOBUF_FILES); do \
 			protoc --plugin=protoc-gen-nanopb=$(PROTOC_GEN_NANOPB) \
 				--nanopb_out="$$D" \

--- a/tests/pkg_nanopb/README.md
+++ b/tests/pkg_nanopb/README.md
@@ -8,22 +8,3 @@ The library provides a Google Protocol Buffers encoder / decoder.
 Install the protobuf compiler and the protobuf python bindings.
 On Debian/ubuntu, the corresponding packages are `protobuf-compiler` and
 `python-protobuf`. On Arch, it is `protobuf` and `python-protobuf`.
-
-You'll also need the nanopb protoc generator plugin.
-
-Checkout the matching nanopb repository:
-
-    $ git clone https://github.com/nanopb/nanopb nanopb-0.3.9.3
-    $ cd nanopb/generator/proto
-
-Take note of the path to `nanopb/generator`.
-
-The build system needs to know the location of the generator plugin.
-Assuming nanopb has been checked out into `~/src/nanopb`, you'll need to prefix
-all make invocations with
-```PROTOC_GEN_NANOPB=~/src/nanopb/generator/protoc-gen-nanopb```.
-
-E.g., to compile this test:
-
-    PROTOC_GEN_NANOPB=~/src/nanopb/generator/protoc-gen-nanopb make \
-        clean all -j4


### PR DESCRIPTION
### Contribution description
No need to request manual intervention by the user, your PR already includes everything to make nanopb just work™ with only minor additions.

### Testing procedure
Just build `tests/pkg_nanopb`

### Issues/PRs references
https://github.com/RIOT-OS/RIOT/pull/11565
